### PR TITLE
feat: add Mastodon embed component

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "astro-remote": "^0.2.4",
     "fuse.js": "^7.0.0",
     "github-slugger": "^2.0.0",
+    "react-icons": "^4.12.0",
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",
     "satori": "^0.10.8",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@fontsource/atkinson-hyperlegible": "^5.0.17",
     "@resvg/resvg-js": "^2.4.1",
     "astro": "^3.1.3",
+    "astro-remote": "^0.2.4",
     "fuse.js": "^7.0.0",
     "github-slugger": "^2.0.0",
     "remark-collapse": "^0.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   github-slugger:
     specifier: ^2.0.0
     version: 2.0.0
+  react-icons:
+    specifier: ^4.12.0
+    version: 4.12.0(react@18.2.0)
   remark-collapse:
     specifier: ^0.1.2
     version: 0.1.2
@@ -3798,7 +3801,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -4880,6 +4882,14 @@ packages:
       scheduler: 0.23.0
     dev: true
 
+  /react-icons@4.12.0(react@18.2.0):
+    resolution: {integrity: sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==}
+    peerDependencies:
+      react: '*'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
@@ -4890,7 +4900,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
 
   /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   astro:
     specifier: ^3.1.3
     version: 3.6.4(@types/node@18.19.2)(typescript@5.3.2)
+  astro-remote:
+    specifier: ^0.2.4
+    version: 0.2.4
   fuse.js:
     specifier: ^7.0.0
     version: 7.0.0
@@ -1822,6 +1825,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /astro-remote@0.2.4:
+    resolution: {integrity: sha512-iMFOuEVaLPWixNhx4acQc7h9ODMsLElb8itVpyREC/xPsUVf+124Nt80LIdFGV93lmYhIiFu2yf87cdsOxoubg==}
+    dependencies:
+      entities: 4.5.0
+      marked: 4.3.0
+      ultrahtml: 0.1.3
+    dev: false
 
   /astro@3.6.4(@types/node@18.19.2)(typescript@5.3.2):
     resolution: {integrity: sha512-YatUyWEQ9GUC79Wc2zbovy6D6bXPW9++Z6PYs4GDamEDspUSnnzL/INB7WJqgFI0xAFk9jcUr+MZYjkdWqXYTw==}
@@ -3809,6 +3820,12 @@ packages:
   /markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
 
+  /marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
+    dev: false
+
   /mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
     dependencies:
@@ -5712,6 +5729,10 @@ packages:
     resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /ultrahtml@0.1.3:
+    resolution: {integrity: sha512-P24ulZdT9UKyQuKA1IApdAZ+F9lwruGvmKb4pG3+sMvR3CjN0pjawPnxuSABHQFB+XqnB35TVXzJPOBYjCv6Kw==}
+    dev: false
 
   /ultrahtml@1.5.2:
     resolution: {integrity: sha512-qh4mBffhlkiXwDAOxvSGxhL0QEQsTbnP9BozOK3OYPEGvPvdWzvAUaXNtUSMdNsKDtuyjEbyVUPFZ52SSLhLqw==}

--- a/src/components/MastodonEmbed/MastodonEmbed.astro
+++ b/src/components/MastodonEmbed/MastodonEmbed.astro
@@ -7,10 +7,9 @@ import { Markup } from "astro-remote";
 
 interface Props {
   url: string;
-  variant?: "dark" | "light";
 }
 
-const { url, variant } = Astro.props;
+const { url } = Astro.props;
 
 const instance = new URL(url).hostname;
 const splitPathname = url.split("/");
@@ -21,7 +20,6 @@ let userUrl;
 
 try {
   const res = await fetch(`https://${instance}/api/v1/statuses/${tootId}`);
-  console.log(res);
   toot = (await res.json()) || [];
   userUrl = new URL(toot?.account?.url)?.hostname;
 } catch (err) {
@@ -30,13 +28,13 @@ try {
 }
 ---
 
-<div class:list={["container", variant || null]}>
+<div class:list={["container"]}>
   {
     !toot ? (
       <p>Post not found.</p>
     ) : (
-      <aside class="flex flex-col max-w-md border-2 border-gray-200 dark:border-gray-800 rounded-md p-4 prose prose-md">
-        <div class="flex flex-row border border-gray-200 dark:border-gray-800 rounded-md p-4">
+      <aside class="container flex flex-col max-w-md border-2 border-gray-200 dark:border-gray-800 rounded-md p-4 prose prose-md">
+        <div class="flex flex-row  dark:border-gray-800 rounded-md">
           <div class="border border-red-200 flex flex-col text-center">
             <a href={toot.account.url} class="justify-end" target="_blank">
             <img

--- a/src/components/MastodonEmbed/MastodonEmbed.astro
+++ b/src/components/MastodonEmbed/MastodonEmbed.astro
@@ -1,9 +1,9 @@
 ---
 // Inspired by https://github.com/ghall89/astro-mastodon-embed
 import { Markup } from "astro-remote";
+import { FaStar, FaRetweet, FaReply } from 'react-icons/fa'
+import type { MastodonPost } from 'types';
 
-// TODO: Add support for icons
-// import Icon from "./src/svg/Icon.astro";
 
 interface Props {
   url: string;
@@ -15,69 +15,77 @@ const instance = new URL(url).hostname;
 const splitPathname = url.split("/");
 const tootId = splitPathname[splitPathname.length - 1];
 
-let toot;
+let toot: MastodonPost | undefined;
 let userUrl;
 
 try {
   const res = await fetch(`https://${instance}/api/v1/statuses/${tootId}`);
-  toot = (await res.json()) || [];
+  if(res.status !== 200 ) throw new Error;
+  toot = await res.json()
+  if(!toot) throw new Error("Unable to load the post")
   userUrl = new URL(toot?.account?.url)?.hostname;
+  console.log(toot)
 } catch (err) {
   console.log(err);
-  throw new Error("Unable to fetch toot");
 }
 ---
 
 <div class:list={["container"]}>
   {
     !toot ? (
-      <p>Post not found.</p>
+      <div class="border border-1 rounded-md bg-grey-100 border-gray-500 p-5 max-w-1/4 text-center prose prose-sm">
+      <p>A Mastodon post was supposed to be here, alas I couldn't find it for you. Was it deleted perhaps? It happens more often than you think!</p>
+      </div>
     ) : (
-      <aside class="container flex flex-col max-w-md border-2 border-gray-200 dark:border-gray-800 rounded-md p-4 prose prose-md">
-        <div class="flex flex-row  dark:border-gray-800 rounded-md">
-          <div class="border border-red-200 flex flex-col text-center">
-            <a href={toot.account.url} class="justify-end" target="_blank">
-            <img
-            class="rounded-full w-20 h-20"
-              src={toot.account.avatar}
-              alt={`${toot.account.username}'s avatar`}
-            />
-            {`@${toot.account.username}`}
-            <br />
-            <span>{`@${userUrl}`}</span>
-          </a>
-          </div>
-          <div class="post-body">
-            <Markup content={toot.content} />
-          </div>
-          {toot.media_attachments.length === 0 ? null : (
-            <div class="post-img">
+      <aside class="container min-w-sm max-w-lg bg-grey-100 border border-gray-500 rounded-md p-4 prose">
+        <div class="flex flex-col ">
+          <div class="flex max-w-20">
+            <div class="flex flex-row text-center w-1/4">
+              <a href={toot.account.url} class="text-sm" target="_blank">
               <img
-                src={toot.media_attachments[0].url}
-                alt={toot.media_attachments[0].description}
+              class="rounded-full w-20 h-20"
+                src={toot.account.avatar}
+                alt={`${toot.account.username}'s avatar`}
               />
+              {`@${toot.account.username}`}
+              <br />
+              <span>{`@${userUrl}`}</span>
+            </a>
             </div>
-          )}
-        </div>
-        <div class="footer">
-          <div class="toot-stats">
-            <span>
-              <!-- <Icon icon="reply-fill" /> -->
-              Replies: {toot.replies_count}
-            </span>
-            <span>
-              <!-- <Icon icon="repeat" /> --> 
-                Boosts: {toot.reblogs_count}
-            </span>
-            <span>
-              <!--<Icon icon="star-fill" /> -->
-              Stars: {toot.favourites_count}
-            </span>
+            <div class="p-2 m-0 prose prose-md w-3/4">
+              <Markup content={toot.content} />
+              <div class="flex flex-row flex-wrap">
+              {toot.media_attachments && (
+                toot.media_attachments.map(image => 
+                  <img
+                    class="w-40 h-40 object-cover"
+                    src={image.url}
+                    alt={image.description}
+                  />
+                  )
+                )}
+              </div>
+            </div>
           </div>
-          <a href={toot.url} target="_blank">
-            View Original Post
-          </a>
         </div>
+        <footer>
+          <div class="mt-10 flex flex-row w-full text-gray-500 justify-between align-center">
+            <div>
+              <span class="mr-2">
+                <FaReply /> {toot.replies_count}
+              </span>
+              <span class="mr-2">
+                <FaRetweet /> {toot.reblogs_count}
+              </span>
+              <span>
+                <FaStar /> {toot.favourites_count}
+              </span>
+            </div>
+            <a href={toot.url} target="_blank" class="text-sm">
+              View Original Post
+            </a>
+          </div>
+        </footer>
       </aside>
     )
   }

--- a/src/components/MastodonEmbed/MastodonEmbed.astro
+++ b/src/components/MastodonEmbed/MastodonEmbed.astro
@@ -1,0 +1,86 @@
+---
+// Inspired by https://github.com/ghall89/astro-mastodon-embed
+import { Markup } from "astro-remote";
+
+// TODO: Add support for icons
+// import Icon from "./src/svg/Icon.astro";
+
+interface Props {
+  url: string;
+  variant?: "dark" | "light";
+}
+
+const { url, variant } = Astro.props;
+
+const instance = new URL(url).hostname;
+const splitPathname = url.split("/");
+const tootId = splitPathname[splitPathname.length - 1];
+
+let toot;
+let userUrl;
+
+try {
+  const res = await fetch(`https://${instance}/api/v1/statuses/${tootId}`);
+  console.log(res);
+  toot = (await res.json()) || [];
+  userUrl = new URL(toot?.account?.url)?.hostname;
+} catch (err) {
+  console.log(err);
+  throw new Error("Unable to fetch toot");
+}
+---
+
+<div class:list={["container", variant || null]}>
+  {
+    !toot ? (
+      <p>Post not found.</p>
+    ) : (
+      <aside class="flex flex-col max-w-md border-2 border-gray-200 dark:border-gray-800 rounded-md p-4 prose prose-md">
+        <div class="flex flex-row border border-gray-200 dark:border-gray-800 rounded-md p-4">
+          <div class="border border-red-200 flex flex-col text-center">
+            <a href={toot.account.url} class="justify-end" target="_blank">
+            <img
+            class="rounded-full w-20 h-20"
+              src={toot.account.avatar}
+              alt={`${toot.account.username}'s avatar`}
+            />
+            {`@${toot.account.username}`}
+            <br />
+            <span>{`@${userUrl}`}</span>
+          </a>
+          </div>
+          <div class="post-body">
+            <Markup content={toot.content} />
+          </div>
+          {toot.media_attachments.length === 0 ? null : (
+            <div class="post-img">
+              <img
+                src={toot.media_attachments[0].url}
+                alt={toot.media_attachments[0].description}
+              />
+            </div>
+          )}
+        </div>
+        <div class="footer">
+          <div class="toot-stats">
+            <span>
+              <!-- <Icon icon="reply-fill" /> -->
+              Replies: {toot.replies_count}
+            </span>
+            <span>
+              <!-- <Icon icon="repeat" /> --> 
+                Boosts: {toot.reblogs_count}
+            </span>
+            <span>
+              <!--<Icon icon="star-fill" /> -->
+              Stars: {toot.favourites_count}
+            </span>
+          </div>
+          <a href={toot.url} target="_blank">
+            View Original Post
+          </a>
+        </div>
+      </aside>
+    )
+  }
+</div>

--- a/src/components/MastodonEmbed/MastodonEmbed.astro
+++ b/src/components/MastodonEmbed/MastodonEmbed.astro
@@ -4,7 +4,6 @@ import { Markup } from "astro-remote";
 import { FaStar, FaRetweet, FaReply } from 'react-icons/fa'
 import type { MastodonPost } from 'types';
 
-
 interface Props {
   url: string;
 }
@@ -13,18 +12,18 @@ const { url } = Astro.props;
 
 const instance = new URL(url).hostname;
 const splitPathname = url.split("/");
-const tootId = splitPathname[splitPathname.length - 1];
+const postId = splitPathname[splitPathname.length - 1];
 
-let toot: MastodonPost | undefined;
+let post: MastodonPost | undefined;
 let userUrl;
 
 try {
-  const res = await fetch(`https://${instance}/api/v1/statuses/${tootId}`);
+  const res = await fetch(`https://${instance}/api/v1/statuses/${postId}`);
   if(res.status !== 200 ) throw new Error;
-  toot = await res.json()
-  if(!toot) throw new Error("Unable to load the post")
-  userUrl = new URL(toot?.account?.url)?.hostname;
-  console.log(toot)
+  post = await res.json()
+  if(!post) throw new Error("Unable to load the post")
+  userUrl = new URL(post?.account?.url)?.hostname;
+  console.log(post)
 } catch (err) {
   console.log(err);
 }
@@ -32,31 +31,31 @@ try {
 
 <div class:list={["container"]}>
   {
-    !toot ? (
-      <div class="border border-1 rounded-md bg-grey-100 border-gray-500 p-5 max-w-1/4 text-center prose prose-sm">
+    !post ? (
+      <div class="my-5 border border-1 rounded-md bg-grey-100 border-gray-500 p-5 max-w-1/4 text-center prose prose-sm">
       <p>A Mastodon post was supposed to be here, alas I couldn't find it for you. Was it deleted perhaps? It happens more often than you think!</p>
       </div>
     ) : (
-      <aside class="container min-w-sm max-w-lg bg-grey-100 border border-gray-500 rounded-md p-4 prose">
+      <aside class="my-5 container min-w-sm max-w-lg bg-grey-100 border border-gray-500 rounded-md p-4 prose">
         <div class="flex flex-col ">
           <div class="flex max-w-20">
             <div class="flex flex-row text-center w-1/4">
-              <a href={toot.account.url} class="text-sm" target="_blank">
+              <a href={post.account.url} class="text-sm" target="_blank">
               <img
               class="rounded-full w-20 h-20"
-                src={toot.account.avatar}
-                alt={`${toot.account.username}'s avatar`}
+                src={post.account.avatar}
+                alt={`${post.account.username}'s avatar`}
               />
-              {`@${toot.account.username}`}
+              {`@${post.account.username}`}
               <br />
               <span>{`@${userUrl}`}</span>
             </a>
             </div>
             <div class="p-2 m-0 prose prose-md w-3/4">
-              <Markup content={toot.content} />
+              <Markup content={post.content} />
               <div class="flex flex-row flex-wrap">
-              {toot.media_attachments && (
-                toot.media_attachments.map(image => 
+              {post.media_attachments && (
+                post.media_attachments.map(image => 
                   <img
                     class="w-40 h-40 object-cover"
                     src={image.url}
@@ -72,16 +71,16 @@ try {
           <div class="mt-10 flex flex-row w-full text-gray-500 justify-between align-center">
             <div>
               <span class="mr-2">
-                <FaReply /> {toot.replies_count}
+                <FaReply /> {post.replies_count}
               </span>
               <span class="mr-2">
-                <FaRetweet /> {toot.reblogs_count}
+                <FaRetweet /> {post.reblogs_count}
               </span>
               <span>
-                <FaStar /> {toot.favourites_count}
+                <FaStar /> {post.favourites_count}
               </span>
             </div>
-            <a href={toot.url} target="_blank" class="text-sm">
+            <a href={post.url} target="_blank" class="text-sm">
               View Original Post
             </a>
           </div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -22,6 +22,9 @@ import MastodonEmbed from '@components/MastodonEmbed/MastodonEmbed.astro'
       >
         Go back home
       </LinkButton>
+      <MastodonEmbed url="https://mindly.social/@Coreyartus/111570037847314700" />
+      <MastodonEmbed url="https://mastodon.social/@Mrfunkedude/111582294846700597" />
+      <MastodonEmbed url="https://lounge.town/@georgetakei@universeodon.com/111569344662211740" />
       <MastodonEmbed url="https://mastodon.social/@molly0xfff@hachyderm.io/111580813730059796" />
     </div>
   </main>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -22,7 +22,7 @@ import MastodonEmbed from '@components/MastodonEmbed/MastodonEmbed.astro'
       >
         Go back home
       </LinkButton>
-      <MastodonEmbed url="https://lounge.town/@georgetakei@universeodon.com/111569344662211740" />
+      <MastodonEmbed url="https://mastodon.social/@molly0xfff@hachyderm.io/111580813730059796" />
     </div>
   </main>
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,6 +4,8 @@ import Layout from "@layouts/Layout.astro";
 import Header from "@components/Header.astro";
 import Footer from "@components/Footer.astro";
 import LinkButton from "@components/LinkButton.astro";
+import MastodonEmbed from '@components/MastodonEmbed/MastodonEmbed.astro'
+
 ---
 
 <Layout title={`404 Not Found | ${SITE.title}`}>
@@ -20,6 +22,7 @@ import LinkButton from "@components/LinkButton.astro";
       >
         Go back home
       </LinkButton>
+      <MastodonEmbed url="https://lounge.town/@georgetakei@universeodon.com/111569344662211740" />
     </div>
   </main>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,13 @@ export type SocialMedia =
   | 'Mastodon';
 
 // Mastodon post types
+type Emoji = {
+  shortcode: string;
+  static_url: string;
+  url: string;
+  visible_in_picker: boolean;
+};
+
 type Account = {
   id: string;
   username: string;
@@ -50,7 +57,7 @@ type Account = {
   statuses_count: number;
   last_status_at: string;
   noindex: boolean;
-  emojis: any[]; // Adjust to match  emojis types
+  emojis: Emoji[]; // Adjust to match  emojis types
   roles: any[]; // Specify (or figure out) types of roles
   fields: any[]; // Specify the type (what is it?..)
 };
@@ -59,6 +66,19 @@ type Tag = {
   name: string;
   url: string;
 };
+
+type Poll = {
+  id: string,
+  expires_at:string,
+  expired: boolean,
+  multiple: boolean,
+  votes_count: number,
+  voters_count: number,
+  options: [
+  { title: string, votes_count: number }
+  ],
+  emojis: Emoji[]
+}
 
 type Card = {
   url: string;
@@ -105,7 +125,7 @@ export type MastodonPost = {
   media_attachments: any[]; // Specify the type/structure for media attachments
   mentions: any[]; // Specify the type/ structure for mentions
   tags: Tag[];
-  emojis: any[]; // Adjust to  specific type for emojis
+  emojis: Emoji[];
   card: Card | null;
-  poll: any | null; // Specify the type/ structure for poll
+  poll: Poll | null;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,3 +26,86 @@ export type SocialMedia =
   | "GitLab"
   | "Steam"
   | "Mastodon";
+
+// Mastodon post types
+type Account = {
+  id: string;
+  username: string;
+  acct: string;
+  display_name: string;
+  locked: boolean;
+  bot: boolean;
+  discoverable: boolean;
+  group: boolean;
+  created_at: string;
+  note: string;
+  url: string;
+  uri: string;
+  avatar: string;
+  avatar_static: string;
+  header: string;
+  header_static: string;
+  followers_count: number;
+  following_count: number;
+  statuses_count: number;
+  last_status_at: string;
+  noindex: boolean;
+  emojis: any[]; // Adjust if you have a specific type for emojis
+  roles: any[]; // Specify the type if you have a structure for roles
+  fields: any[]; // Specify the type if you have a structure for fields
+};
+
+type Tag = {
+  name: string;
+  url: string;
+};
+
+type Card = {
+  url: string;
+  title: string;
+  description: string;
+  language: string;
+  type: string;
+  author_name: string;
+  author_url: string;
+  provider_name: string;
+  provider_url: string;
+  html: string;
+  width: number;
+  height: number;
+  image: string;
+  image_description: string;
+  embed_url: string;
+  blurhash: string;
+  published_at: string | null;
+};
+
+export type MastodonPost = {
+  id: string;
+  created_at: string;
+  in_reply_to_id: string | null;
+  in_reply_to_account_id: string | null;
+  sensitive: boolean;
+  spoiler_text: string;
+  visibility: string;
+  language: string;
+  uri: string;
+  url: string;
+  replies_count: number;
+  reblogs_count: number;
+  favourites_count: number;
+  edited_at: string | null;
+  content: string;
+  reblog: any | null; // Specify the type if you have a structure for reblog
+  application: {
+    name: string;
+    website: string;
+  };
+  account: Account;
+  media_attachments: any[]; // Specify the type if you have a structure for media attachments
+  mentions: any[]; // Specify the type if you have a structure for mentions
+  tags: Tag[];
+  emojis: any[]; // Adjust if you have a specific type for emojis
+  card: Card | null;
+  poll: any | null; // Specify the type if you have a structure for poll
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,12 +20,12 @@ export type SocialIcons = {
 };
 
 export type SocialMedia =
-  | "Github"
-  | "LinkedIn"
-  | "Mail"
-  | "GitLab"
-  | "Steam"
-  | "Mastodon";
+  | 'Github'
+  | 'LinkedIn'
+  | 'Mail'
+  | 'GitLab'
+  | 'Steam'
+  | 'Mastodon';
 
 // Mastodon post types
 type Account = {
@@ -50,9 +50,9 @@ type Account = {
   statuses_count: number;
   last_status_at: string;
   noindex: boolean;
-  emojis: any[]; // Adjust if you have a specific type for emojis
-  roles: any[]; // Specify the type if you have a structure for roles
-  fields: any[]; // Specify the type if you have a structure for fields
+  emojis: any[]; // Adjust to match  emojis types
+  roles: any[]; // Specify (or figure out) types of roles
+  fields: any[]; // Specify the type (what is it?..)
 };
 
 type Tag = {
@@ -77,7 +77,7 @@ type Card = {
   image_description: string;
   embed_url: string;
   blurhash: string;
-  published_at: string | null;
+  published_at: string | null; // when is it ever null?!
 };
 
 export type MastodonPost = {
@@ -96,16 +96,16 @@ export type MastodonPost = {
   favourites_count: number;
   edited_at: string | null;
   content: string;
-  reblog: any | null; // Specify the type if you have a structure for reblog
+  reblog: any; // Specify the type for reblog
   application: {
     name: string;
     website: string;
   };
   account: Account;
-  media_attachments: any[]; // Specify the type if you have a structure for media attachments
-  mentions: any[]; // Specify the type if you have a structure for mentions
+  media_attachments: any[]; // Specify the type/structure for media attachments
+  mentions: any[]; // Specify the type/ structure for mentions
   tags: Tag[];
-  emojis: any[]; // Adjust if you have a specific type for emojis
+  emojis: any[]; // Adjust to  specific type for emojis
   card: Card | null;
-  poll: any | null; // Specify the type if you have a structure for poll
+  poll: any | null; // Specify the type/ structure for poll
 };


### PR DESCRIPTION
This PR introduces a Mastodon Embed component. It takes a post URL and formats a nice-looking embed:

![IMG_0361](https://github.com/rosnovsky/rosnovsky.us/assets/2508576/f42ccbd0-6b43-48d5-a23e-279fea0f991b)


- [x] Add details + screenshot
- [ ] Make it work in markdown _somehow_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a Mastodon Embed component for integrating Mastodon posts into the application.
	- Embedded Mastodon posts now include interaction icons for a more interactive experience.

- **Documentation**
	- Updated the 404 page to demonstrate the new Mastodon Embed feature.

- **Refactor**
	- Added new type declarations to enhance data structure and integrity for Mastodon-related features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->